### PR TITLE
Compatibility with k8s > 1.15 - deployment 

### DIFF
--- a/emby/templates/deployment.yaml
+++ b/emby/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "emby.fullname" . }}

--- a/filebrowser/templates/deployment.yaml
+++ b/filebrowser/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "filebrowser.fullname" . }}

--- a/jackett/templates/deployment.yaml
+++ b/jackett/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "jackett.fullname" . }}
@@ -35,6 +35,8 @@ spec:
 {{ toYaml .Values.volumeMounts | indent 12 }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
+          securityContext:
+{{ toYaml .Values.securityContext | indent 12 }}
     {{- with .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml . | indent 8 }}

--- a/jackett/values.yaml
+++ b/jackett/values.yaml
@@ -50,6 +50,8 @@ resources:
     memory: 256Mi
     cpu: 0.5
 
+securityContext: {}
+
 nodeSelector: {}
 
 tolerations: []

--- a/ombi/templates/deployment.yaml
+++ b/ombi/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "ombi.fullname" . }}

--- a/radarr/templates/deployment.yaml
+++ b/radarr/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "radarr.fullname" . }}

--- a/sftp/templates/deployment.yaml
+++ b/sftp/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "sftp.fullname" . }}

--- a/sonarr/templates/deployment.yaml
+++ b/sonarr/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "sonarr.fullname" . }}

--- a/transmission-openvpn/templates/deployment.yaml
+++ b/transmission-openvpn/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta2
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "transmission-openvpn.fullname" . }}


### PR DESCRIPTION
Hi,
Thanks for the hard work building all those charts. Unfortunately, every `deployment.yaml` files seem to be incompatible with the most recent versions of Kubernetes (> 1.15).

Simply replacing `apiVersion: apps/v1beta2` by `apiVersion: apps/v1` in the deployment files fixes the problem.

I also added the possibility to configure the `securityContext` to Jackett, because in my setup, I'm using my own image [Jacket over VPN](https://hub.docker.com/repository/docker/gjeanmart/jackettvpn) and I need to provide a `NET_ADMIN` capability to the container.

Best,
Greg